### PR TITLE
Enable comma-dangle: always-multiline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "dollar-sign"
   ],
   "rules": {
+    "comma-dangle": ["error", "always-multiline"],
     "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
     "func-names": "off",
     "indent": ["error", 4],

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ For the most part, edX follows the thoroughly documented [Airbnb JavaScript Styl
 
 In addition to the base Airbnb rules, edX adds or extends several of our own. They are described below.
 
+####[`comma-dangle`](http://eslint.org/docs/rules/comma-dangle)
+- **Setting**: `["error", "always-multiline"]`
+- **Explanation**: In objects split onto multiple lines, the last key/value pair should have a trailing comma. This makes diffs cleaner, and follows Airbnb's recommendation for code that doesn't need to support IE8.
+- **Example**:
+
+    ```javascript
+    // Correct pattern
+    var correct = {
+        foo: 'foo',
+        bar: 'bar',
+    }
+
+    var alsoCorrect = { foo: 'foo', bar: 'bar' };
+
+    // Linter error
+    var incorrect = {
+        foo: 'foo',
+        bar: 'bar'
+    }
+    ```
+
 ####[`dollar-sign`](https://github.com/erikdesjardins/eslint-plugin-dollar-sign)
 - **Setting**: `["error", "ignoreProperties"]`
 - **Explanation**: All variables that represent jQuery objects should be named starting with a `$`. Object properties may ignore this rule.

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@
     return function() {
         var propertyQuote = {
                 bar: 'buzz',
-                'mixed-quote-prop': 'mixed quotes are ok!'
+                'mixed-quote-prop': 'mixed quotes are ok!',
             },
             simpleESLintTest = 'This file should have no errors';
 


### PR DESCRIPTION
## Description

(copied from doc)
#### [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle)
- **Setting**: `["error", "always-multiline"]`
- **Explanation**: In objects split onto multiple lines, the last key/value pair should have a trailing comma. This makes diffs cleaner, and follows Airbnb's recommendation for code that doesn't need to support IE8.
- **Example**:
  
  ``` javascript
  // Correct pattern
  var correct = {
      foo: 'foo',
      bar: 'bar',
  }
  
  var alsoCorrect = { foo: 'foo', bar: 'bar' };
  
  // Linter error
  var incorrect = {
      foo: 'foo',
      bar: 'bar'
  }
  ```
## Reviewers

a majority of
- [ ] @andy-armstrong 
- [ ] @alisan617
- [ ] @AlasdairSwan 
- [ ] @dsjen 

FYI @bradenmacdonald
## Note

Because this will cause code which currently passes the linter to stop passing the linter when it is merged, I consider this a "breaking change" - hence it will need to be released as `2.0.0`.
